### PR TITLE
Fixing manifest link so it doesn't error on update

### DIFF
--- a/module.json
+++ b/module.json
@@ -13,6 +13,6 @@
   ],
   "author": "Daxiongmao87",
   "url": "https://github.com/Daxiongmao87/foundry-vtt-5e-phb-journal-styling",
-  "manifest": "https://github.com/Daxiongmao87/foundry-vtt-5e-phb-journal-styling/blob/main/module.json",
+  "manifest": "https://raw.githubusercontent.com/Daxiongmao87/foundry-vtt-5e-phb-journal-styling/main/module.json",
   "download": "https://github.com/Daxiongmao87/foundry-vtt-5e-phb-journal-styling/archive/refs/heads/main.zip"
 }


### PR DESCRIPTION
The old manifest link pointed to the GitHub interface viewing the manifest file, you need the raw manifest file (equivalent to clicking Raw in the GitHub interface).

Love the module btw 😄